### PR TITLE
rename soundtracks application

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project uses Java and requires JDK 17. To start the project, open a new ter
 
 `./gradlew bootRun`
 
-Or navigate to the `SpotifyDemoApplication.java` file and click `Run` in your IDE.
+Or navigate to the `SoundtracksApplication.java` file and click `Run` in your IDE.
 
 The `final` branch of this repo contains the final stage of the course, with all of the steps and code completed! If you get stuck, you can refer to it and compare your code.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,6 @@ tasks.withType<Test> {
 }
 
 tasks.generateJava {
-	packageName = "com.example.spotifydemo.generated"
+	packageName = "com.example.soundtracks.generated"
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "spotify-demo"
+rootProject.name = "soundtracks"

--- a/src/main/java/com/example/soundtracks/SoundtracksApplication.java
+++ b/src/main/java/com/example/soundtracks/SoundtracksApplication.java
@@ -1,4 +1,4 @@
-package com.example.spotifydemo;
+package com.example.soundtracks;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/example/soundtracks/WebConfiguration.java
+++ b/src/main/java/com/example/soundtracks/WebConfiguration.java
@@ -1,4 +1,4 @@
-package com.example.spotifydemo;
+package com.example.soundtracks;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/src/main/java/com/example/spotifydemo/SoundtracksApplication.java
+++ b/src/main/java/com/example/spotifydemo/SoundtracksApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class SpotifyDemoApplication {
+public class SoundtracksApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(SpotifyDemoApplication.class, args);
+		SpringApplication.run(SoundtracksApplication.class, args);
 	}
 
 }

--- a/src/test/java/com/example/soundtracks/SoundtracksApplicationTests.java
+++ b/src/test/java/com/example/soundtracks/SoundtracksApplicationTests.java
@@ -1,10 +1,10 @@
-package com.example.spotifydemo;
+package com.example.soundtracks;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class SpotifyDemoApplicationTests {
+class SoundtracksApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
- rename from `SpotifyDemoApplication` to `SoundtracksApplication`
- remove references to `spotify-demo` and replace with `soundtracks`

**AFTER MERGE**, we'll [rename the starter code repository](https://github.com/apollographql-education/dgs-spotify/settings) from `dgs-spotify` to `intro-dgs`.